### PR TITLE
refactor(inference): complete model registry with register_predictor() and get_available_models()

### DIFF
--- a/src/inference.py
+++ b/src/inference.py
@@ -224,14 +224,30 @@ _PREDICTORS: dict[str, Predictor] = {
 }
 
 
-def register_predictor(name: str, predictor: Predictor) -> None:
+def register_predictor(
+    name: str, predictor: Predictor, *, overwrite: bool = False
+) -> None:
     """Register a new predictor under the given model name.
 
     Allows adding future models (e.g. RoBERTa) without editing this module:
 
         from src.inference import register_predictor
         register_predictor("roberta", RoBERTaPredictor())
+
+    Raises:
+        TypeError:  If predictor does not implement the Predictor protocol.
+        ValueError: If name is already registered and overwrite=False.
     """
+    if not isinstance(predictor, Predictor):
+        raise TypeError(
+            f"predictor must implement the Predictor protocol (needs a predict() method), "
+            f"got {type(predictor).__name__!r}"
+        )
+    if name in _PREDICTORS and not overwrite:
+        raise ValueError(
+            f"Predictor '{name}' is already registered. "
+            "Pass overwrite=True to replace it."
+        )
     _PREDICTORS[name] = predictor
 
 

--- a/src/inference.py
+++ b/src/inference.py
@@ -224,6 +224,22 @@ _PREDICTORS: dict[str, Predictor] = {
 }
 
 
+def register_predictor(name: str, predictor: Predictor) -> None:
+    """Register a new predictor under the given model name.
+
+    Allows adding future models (e.g. RoBERTa) without editing this module:
+
+        from src.inference import register_predictor
+        register_predictor("roberta", RoBERTaPredictor())
+    """
+    _PREDICTORS[name] = predictor
+
+
+def get_available_models() -> tuple[str, ...]:
+    """Return the names of all currently registered models."""
+    return tuple(_PREDICTORS.keys())
+
+
 # ---------------------------------------------------------------------------
 # Backward-compat flat functions (call concrete instances directly)
 # ---------------------------------------------------------------------------
@@ -269,7 +285,8 @@ def predict_sentiment(text: str, model_name: str = MODEL_BASELINE) -> dict:
     """
     if model_name not in _PREDICTORS:
         raise ValueError(
-            f"Unknown model '{model_name}'. Choose from {ALL_MODELS}."
+            f"Unknown model '{model_name}'. "
+            f"Available: {get_available_models()}."
         )
     return _PREDICTORS[model_name].predict(text)
 

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -192,6 +192,59 @@ def test_predict_sentiment_invalid_model_raises(artefacts):
 
 
 # ---------------------------------------------------------------------------
+# register_predictor / get_available_models
+# ---------------------------------------------------------------------------
+
+class _DummyPredictor:
+    def predict(self, text: str) -> dict:
+        return {"label": "Positive review", "confidence": 1.0, "model": "dummy"}
+
+
+def test_get_available_models_contains_defaults():
+    from src.inference import get_available_models
+    models = get_available_models()
+    assert "baseline" in models
+    assert "bilstm" in models
+    assert "distilbert" in models
+
+
+def test_register_predictor_and_predict(artefacts):
+    import src.inference as inf_mod
+    from src.inference import register_predictor, predict_sentiment, get_available_models
+    # Clean up after test regardless of outcome
+    try:
+        register_predictor("dummy", _DummyPredictor())
+        assert "dummy" in get_available_models()
+        result = predict_sentiment("anything", model_name="dummy")
+        assert result["model"] == "dummy"
+    finally:
+        inf_mod._PREDICTORS.pop("dummy", None)
+
+
+def test_register_predictor_rejects_invalid_object():
+    from src.inference import register_predictor
+    with pytest.raises(TypeError, match="Predictor protocol"):
+        register_predictor("bad", object())
+
+
+def test_register_predictor_rejects_duplicate():
+    from src.inference import register_predictor
+    with pytest.raises(ValueError, match="already registered"):
+        register_predictor("baseline", _DummyPredictor())
+
+
+def test_register_predictor_overwrite_allowed():
+    import src.inference as inf_mod
+    from src.inference import register_predictor
+    original = inf_mod._PREDICTORS.get("baseline")
+    try:
+        register_predictor("baseline", _DummyPredictor(), overwrite=True)
+        assert inf_mod._PREDICTORS["baseline"] is not original
+    finally:
+        inf_mod._PREDICTORS["baseline"] = original
+
+
+# ---------------------------------------------------------------------------
 # integration — real saved artefacts
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

The \`_PREDICTORS\` registry and dispatch were introduced in #32. This PR completes the registry story for #33:

- Adds \`register_predictor(name, predictor, *, overwrite=False)\` — validates the Predictor protocol at registration time, blocks silent overwrites by default, accepts \`overwrite=True\` for intentional replacement
- Adds \`get_available_models()\` — returns the live registry keys as a tuple
- \`predict_sentiment()\` error message now reflects the live registry via \`get_available_models()\`, not the hardcoded \`ALL_MODELS\` constant

## Test plan

- [x] \`pytest tests/ -q -m "not slow"\` — 148 passed, 0 failed
- [x] \`register_predictor("dummy", _DummyPredictor())\` registers and routes correctly
- [x] \`register_predictor("bad", object())\` raises \`TypeError: Predictor protocol\`
- [x] \`register_predictor("baseline", ...)\` raises \`ValueError: already registered\`
- [x] \`register_predictor("baseline", ..., overwrite=True)\` succeeds

Closes #33. Depends on #32.