### PR TITLE
feat(app): extract model loading into app service layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ data/books
 data/dvd
 data/electronics
 data/kitchen_&_housewares
+docs/other
+.pytest_cache/

--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,5 @@
+[server]
+# Transformers' vision models import torchvision at module inspection time,
+# which Streamlit's default watchdog watcher triggers on hot-reload. Switching
+# to poll mode avoids traversing transformers' __path__ and silences the noise.
+fileWatcherType = "poll"

--- a/app.py
+++ b/app.py
@@ -33,7 +33,7 @@ st.set_page_config(
 # ---------------------------------------------------------------------------
 
 st.logo("logo-icon.png", link=None)   # icon in the top-left chrome
-st.sidebar.image("logo.jpeg", use_container_width=True)
+st.sidebar.image("logo.jpeg", width='content')
 
 # ---------------------------------------------------------------------------
 # Header
@@ -69,20 +69,8 @@ else:
 # Sample reviews
 # ---------------------------------------------------------------------------
 
-_SAMPLES = [
-    # positive
-    "This blender is incredible — smoothies in under 30 seconds, easy to clean, and still going strong after six months of daily use.",
-    "Absolutely love this book. The writing is sharp, the characters feel real, and I stayed up until 2 AM to finish it. Highly recommended.",
-    "Perfect headphones for the price. Sound quality rivals sets twice the cost, and the battery easily lasts two full days.",
-    "The kitchen knife set exceeded my expectations. Razor sharp out of the box, balanced grip, and the block keeps everything organised.",
-    "Bought this for my daughter's birthday and she hasn't put it down. Great educational toy that actually holds a child's attention.",
-    # negative
-    "Arrived with a cracked screen and the seller took three weeks to respond. Complete waste of money — avoid.",
-    "The straps broke on the second use. Cheap stitching, flimsy buckles. Returned immediately and won't be buying from this brand again.",
-    "Sound cuts out every few minutes. I thought it was a pairing issue but the replacement unit had the same problem. Terrible quality control.",
-    "This DVD player skips on every disc I try. The remote is unresponsive half the time. Returned after one day.",
-    "Poorly written instructions, missing hardware, and customer support just copy-pasted the same unhelpful reply three times. Deeply frustrating.",
-]
+from src.utils.samples import get_random_sample, get_all_samples
+_SAMPLES = get_all_samples()  # cache all samples for quick access
 
 # Session state key for the text area value
 if "review_text" not in st.session_state:
@@ -90,10 +78,9 @@ if "review_text" not in st.session_state:
 
 
 def _load_random_sample():
-    import random
+    """Load a random sample into session state."""
     current = st.session_state.get("review_text", "")
-    candidates = [s for s in _SAMPLES if s != current]
-    st.session_state["review_text"] = random.choice(candidates)
+    st.session_state["review_text"] = get_random_sample(current)
 
 
 # ---------------------------------------------------------------------------
@@ -118,7 +105,7 @@ classify = st.button(
     "Classify",
     type="primary",
     disabled=not text.strip(),
-    use_container_width=True,
+    width='content',
 )
 
 # ---------------------------------------------------------------------------

--- a/app.py
+++ b/app.py
@@ -7,7 +7,13 @@ Usage:
 from PIL import Image
 import streamlit as st
 
-from src.config import MODEL_BASELINE, MODEL_BILSTM, MODEL_DISTILBERT
+from src.app_service import (
+    DISTILBERT_UNAVAILABLE_MSG,
+    MODEL_OPTIONS,
+    is_distilbert_available,
+    warm_up_model,
+)
+from src.config import MODEL_DISTILBERT
 
 # ---------------------------------------------------------------------------
 # Page config — must be the first Streamlit call
@@ -30,31 +36,6 @@ st.logo("logo-icon.png", link=None)   # icon in the top-left chrome
 st.sidebar.image("logo.jpeg", use_container_width=True)
 
 # ---------------------------------------------------------------------------
-# Model loading — cached for the lifetime of the Streamlit session
-# ---------------------------------------------------------------------------
-
-@st.cache_resource(show_spinner="Loading model…")
-def _load_baseline():
-    from src.inference import load_baseline_model
-    return load_baseline_model()
-
-
-@st.cache_resource(show_spinner="Loading model…")
-def _load_bilstm():
-    from src.inference import load_bilstm_model
-    return load_bilstm_model()
-
-
-@st.cache_resource(show_spinner="Loading model…")
-def _load_distilbert():
-    try:
-        from src.inference import load_distilbert_model
-        return load_distilbert_model()
-    except (ImportError, FileNotFoundError, RuntimeError):
-        return None
-
-
-# ---------------------------------------------------------------------------
 # Header
 # ---------------------------------------------------------------------------
 
@@ -67,18 +48,6 @@ st.divider()
 # Model selector
 # ---------------------------------------------------------------------------
 
-MODEL_OPTIONS = {
-    MODEL_BASELINE:   "TF-IDF + Logistic Regression  (recommended — best test F1)",
-    MODEL_BILSTM:     "BiLSTM + GloVe  (neural model)",
-    MODEL_DISTILBERT: "DistilBERT_base_uncased  (Hugging Face model)",
-}
-
-MODEL_LOADERS = {
-    MODEL_BASELINE:   _load_baseline,
-    MODEL_BILSTM:     _load_bilstm,
-    MODEL_DISTILBERT: _load_distilbert,
-}
-
 model_name = st.radio(
     "Model",
     options=list(MODEL_OPTIONS.keys()),
@@ -90,15 +59,11 @@ model_name = st.radio(
 # Warm up the selected model; check DistilBERT loaded successfully.
 _distilbert_available = True
 if model_name == MODEL_DISTILBERT:
-    if _load_distilbert() is None:
+    if not is_distilbert_available():
         _distilbert_available = False
-        st.warning(
-            "DistilBERT is currently unavailable — the checkpoint or `transformers` "
-            "dependency could not be loaded. Select **Baseline** or **BiLSTM** to continue.",
-            icon="⚠️",
-        )
+        st.warning(DISTILBERT_UNAVAILABLE_MSG, icon="⚠️")
 else:
-    MODEL_LOADERS[model_name]()
+    warm_up_model(model_name)
 
 # ---------------------------------------------------------------------------
 # Sample reviews

--- a/app.py
+++ b/app.py
@@ -69,8 +69,7 @@ else:
 # Sample reviews
 # ---------------------------------------------------------------------------
 
-from src.utils.samples import get_random_sample, get_all_samples
-_SAMPLES = get_all_samples()  # cache all samples for quick access
+from src.utils.samples import get_random_sample
 
 # Session state key for the text area value
 if "review_text" not in st.session_state:

--- a/data/notes.md
+++ b/data/notes.md
@@ -76,7 +76,7 @@ The BiLSTM + GloVe path is the right main model. It's also more defensible in th
 ~~2.~~ Write the XML parser to extract reviews and ratings into a DataFrame.
 ~~3.~~ Clean and preprocess the text, assign binary labels, and drop 3-star reviews.
 ~~4.~~ Inspect the review length distribution to validate outlier removal thresholds.
-5. Implement the TF-IDF + Logistic Regression baseline, evaluate and report results.
-6. Build the BiLSTM model, train it, and evaluate.
-7. If time allows, fine-tune DistilBERT and evaluate on a held-out test set to demonstrate the HD criterion.
-8. Build the Streamlit app wrapping the inference function.
+~~5.~~ Implement the TF-IDF + Logistic Regression baseline, evaluate and report results.
+~~6.~~ Build the BiLSTM model, train it, and evaluate.
+~~7.~~ If time allows, fine-tune DistilBERT and evaluate on a held-out test set to demonstrate the HD criterion.
+~~8.~~ Build the Streamlit app wrapping the inference function.

--- a/docs/issueBreakdownTwo.md
+++ b/docs/issueBreakdownTwo.md
@@ -1,0 +1,334 @@
+# Issue Breakdown II - ReviewPulse Refactor Track
+
+This document tracks the second wave of ReviewPulse work: moving the project from a working assessment build into a cleaner, easier-to-maintain codebase.
+
+The v2.0.0 application already works with three model families:
+
+- baseline: TF-IDF + Logistic Regression
+- neural: BiLSTM + GloVe
+- transformer: Hugging Face DistilBERT
+
+The refactor track is not about chasing higher metrics first. It is about making the codebase easier to understand, safer to extend, and cleaner to explain in a portfolio or technical interview.
+
+## Mental Model
+
+Keep these four concerns separate:
+
+| Concern | Question it answers | Current entrypoint |
+|---|---|---|
+| Training | How do we create model artifacts? | `python -m src.baseline`, `python -m src.train`, `python -m src.train_bert` |
+| Inference | How do we predict one user-provided review? | `src.inference.predict_sentiment()` |
+| Evaluation | How do we score models on the held-out test split? | `python -m src.evaluate` |
+| App | How does the user interact with the models? | `streamlit run app.py` |
+
+Training produces artifacts. Inference consumes artifacts for one review. Evaluation consumes artifacts and test data for metrics. The app should only orchestrate UI and call inference.
+
+---
+
+## Status Snapshot
+
+| Issue | Status | Purpose |
+|---|---|---|
+| #30 | Closed | Architecture documentation and target boundaries |
+| #31 | Open | Centralize paths, model names, and shared constants |
+| #32 | Open | Introduce a predictor interface for all models |
+| #33 | Open | Replace inference branching with a model registry |
+| #34 | Open | Separate evaluation metrics from artifact/report writing |
+| #35 | Open | Reuse shared prediction logic in evaluation where practical |
+| #36 | Open | Split DistilBERT training and checkpoint concerns |
+| #37 | Open | Move Streamlit model availability/loading into an app service |
+| #38 | Open | Document model artifact policy and model-card notes |
+| #39 | Open | Reorganize tests by concern and add refactor safety checks |
+
+---
+
+## Issue #30 - Architecture: document current pipeline and target boundaries
+
+Status: Closed
+
+What landed:
+
+- `docs/architecture.md` explains the current repository layout.
+- Training, inference, evaluation, and app responsibilities are documented as separate concerns.
+- Baseline, BiLSTM, and DistilBERT data flows are documented.
+- Mermaid diagrams were added for the model pipelines.
+- Target refactor boundaries were named for the v2.x cleanup series.
+
+Why it matters:
+
+- This creates a shared map before changing code.
+- It helps avoid refactoring blindly.
+- It gives new contributors a way to understand why the next issues exist.
+
+---
+
+## Issue #31 - Refactor: centralize paths, model names, and shared constants
+
+Status: Open
+
+Goal:
+
+- Create one source of truth for artifact paths, model identifiers, labels, display names, and shared thresholds.
+
+Expected direction:
+
+- Add a small config/constants module, likely `src/config.py`.
+- Move duplicated constants such as `OUTPUTS_DIR`, checkpoint paths, baseline path, vocab path, and valid model names into that module.
+- Update modules to import shared constants instead of redefining them.
+
+Acceptance shape:
+
+- No behavior change.
+- Existing commands still work.
+- Fast tests remain green.
+
+Why it comes first:
+
+- Later issues need stable names and paths before introducing predictors, registries, and cleaner evaluation helpers.
+
+---
+
+## Issue #32 - Refactor: introduce a predictor interface for all models
+
+Status: Open
+
+Goal:
+
+- Give baseline, BiLSTM, and DistilBERT the same single-text prediction contract.
+
+Expected direction:
+
+- Add a simple predictor shape or protocol.
+- Wrap each model behind a common method, for example `predict(text: str) -> dict`.
+- Preserve the current output contract:
+
+```python
+{
+    "label": "Positive review" | "Negative review",
+    "confidence": float,
+    "model": "baseline" | "bilstm" | "distilbert",
+}
+```
+
+Acceptance shape:
+
+- `predict_sentiment()` keeps working.
+- Model loading remains cached.
+- Predictors do not import evaluation plotting code.
+
+Why it matters:
+
+- This makes inference easier to reason about because every model follows the same interface.
+
+---
+
+## Issue #33 - Refactor: simplify inference with a model registry
+
+Status: Open
+
+Goal:
+
+- Replace growing `if/elif` model routing with a small registry.
+
+Expected direction:
+
+- Add a mapping from model name to predictor factory or predictor loader.
+- Keep `"baseline"` as the default model.
+- Keep `"bilstm"` and `"distilbert"` selectable.
+- Preserve clear `ValueError` behavior for invalid model names.
+
+Acceptance shape:
+
+- `predict_sentiment(text, model_name="baseline")` remains the public API.
+- Adding a future model should require registering it, not editing multiple conditionals.
+
+Why it matters:
+
+- This is the bridge from "three hardcoded models" to "a maintainable model comparison app".
+
+---
+
+## Issue #34 - Refactor: separate evaluation metrics from artifact writing
+
+Status: Open
+
+Goal:
+
+- Make evaluation easier to test by separating pure metric computation from side effects.
+
+Expected direction:
+
+- Keep metric helpers separate from CSV/PNG/report writing.
+- Preserve `python -m src.evaluate`.
+- Keep confusion matrix and error analysis outputs.
+
+Acceptance shape:
+
+- Metrics can be tested without writing files.
+- Report writing remains available for the assessment evidence.
+
+Why it matters:
+
+- Evaluation is currently one of the confusing areas because it mixes scoring, plotting, error analysis, and model loading.
+
+---
+
+## Issue #35 - Refactor: reuse shared prediction logic in evaluation where practical
+
+Status: Open
+
+Goal:
+
+- Reduce duplicated prediction behavior between inference and evaluation without making evaluation inefficient.
+
+Expected direction:
+
+- Reuse labels, thresholds, constants, and model contracts from the inference side.
+- Keep batch evaluation efficient for neural models.
+- Do not force the Streamlit single-text path to depend on plotting or evaluation files.
+
+Acceptance shape:
+
+- Existing metrics stay materially the same.
+- Evaluation and inference agree on labels, thresholds, and model names.
+
+Why it matters:
+
+- Inference and evaluation should be consistent, but not tightly coupled.
+
+---
+
+## Issue #36 - Refactor: split DistilBERT training and checkpoint concerns
+
+Status: Open
+
+Goal:
+
+- Break down `src/train_bert.py`, currently the largest and densest module.
+
+Expected direction:
+
+- Separate tokenizer/dataset helpers from the training loop.
+- Separate checkpoint save/load helpers from CLI orchestration.
+- Preserve compatibility with `outputs/distilbert.pt`.
+- Preserve `python -m src.train_bert`.
+
+Acceptance shape:
+
+- DistilBERT tests pass.
+- Existing checkpoint can still be loaded.
+- No retraining is required for the refactor.
+
+Why it matters:
+
+- The transformer implementation is valuable, but it is also the easiest part of the codebase to let become hard to maintain.
+
+---
+
+## Issue #37 - Refactor: move Streamlit model availability and loading into an app service
+
+Status: Open
+
+Goal:
+
+- Keep `app.py` focused on UI and move app-specific loading/availability checks elsewhere.
+
+Expected direction:
+
+- Add a small app service/helper module.
+- Move model availability checks into that layer.
+- Preserve graceful DistilBERT unavailable behavior.
+- Keep core inference in `src.inference`, not inside the UI.
+
+Acceptance shape:
+
+- `streamlit run app.py` behaves the same.
+- The app still uses the inference API or predictor layer.
+- App code becomes easier to scan.
+
+Why it matters:
+
+- UI files become fragile when they also own loading policy, error handling, and model orchestration.
+
+---
+
+## Issue #38 - Docs: add model artifact policy and model card notes
+
+Status: Open
+
+Goal:
+
+- Document what each artifact is, how it is produced, and how it should be handled.
+
+Expected direction:
+
+- Document `baseline.joblib`, `vocab.json`, `bilstm.pt`, and `distilbert.pt`.
+- Explain which artifacts are committed and which generated files are ignored.
+- Explain that the compact DistilBERT checkpoint still depends on the Hugging Face base model.
+- Document security and trust considerations around loading model artifacts.
+- Reference #28 for future external hosting of the DistilBERT checkpoint.
+
+Acceptance shape:
+
+- A maintainer can understand artifact ownership without reading every training file.
+- Deployment limitations are explicit.
+
+Why it matters:
+
+- Model artifacts are part of the architecture, not just random files in `outputs/`.
+
+---
+
+## Issue #39 - Tests: reorganize tests by concern and add refactor safety checks
+
+Status: Open
+
+Goal:
+
+- Make the tests describe the intended architecture and protect the refactor work.
+
+Expected direction:
+
+- Add or reorganize tests around:
+  - config/constants;
+  - predictor interface behavior;
+  - model registry routing;
+  - invalid model handling;
+  - metric helpers without file writes;
+  - app model availability helpers.
+- Keep slow tests marked.
+- Keep BERT tests guarded when `transformers` is unavailable.
+
+Acceptance shape:
+
+- Fast tests pass:
+
+```bash
+pytest tests/ -q -m "not slow"
+```
+
+- Full tests pass when local data/artifacts are available:
+
+```bash
+pytest tests/
+```
+
+Why it matters:
+
+- Refactors are only senior-level work when tests protect behavior while the internals move.
+
+---
+
+## Recommended Execution Order
+
+1. #31 - centralize config/constants.
+2. #32 - introduce predictor interface.
+3. #33 - add model registry.
+4. #34 - split evaluation metrics from file/report writing.
+5. #35 - align evaluation with shared prediction contracts where practical.
+6. #36 - split DistilBERT training/checkpoint code.
+7. #37 - move app loading/availability policy into an app service.
+8. #38 - document artifact policy and model-card notes.
+9. #39 - tighten/refactor tests around the new boundaries.
+
+This order keeps each PR small and reviewable. It also avoids touching Streamlit or DistilBERT internals before the shared constants and prediction contracts are stable.

--- a/src/app_service.py
+++ b/src/app_service.py
@@ -40,7 +40,7 @@ def load_distilbert():
     try:
         from src.inference import load_distilbert_model
         return load_distilbert_model()
-    except (ImportError, FileNotFoundError, RuntimeError):
+    except (ImportError, FileNotFoundError, RuntimeError, OSError):
         return None
 
 

--- a/src/app_service.py
+++ b/src/app_service.py
@@ -1,0 +1,64 @@
+"""Streamlit app service layer for ReviewPulse.
+
+Provides cached model loading and DistilBERT availability helpers so that
+app.py stays focused on layout, input, and result display.
+"""
+
+import streamlit as st
+
+from src.config import MODEL_BASELINE, MODEL_BILSTM, MODEL_DISTILBERT
+
+MODEL_OPTIONS: dict[str, str] = {
+    MODEL_BASELINE:   "TF-IDF + Logistic Regression  (recommended — best test F1)",
+    MODEL_BILSTM:     "BiLSTM + GloVe  (neural model)",
+    MODEL_DISTILBERT: "DistilBERT_base_uncased  (Hugging Face model)",
+}
+
+DISTILBERT_UNAVAILABLE_MSG = (
+    "DistilBERT is currently unavailable — the checkpoint or `transformers` "
+    "dependency could not be loaded. Select **Baseline** or **BiLSTM** to continue."
+)
+
+
+@st.cache_resource(show_spinner="Loading model…")
+def load_baseline():
+    """Load and cache the TF-IDF + LogReg baseline."""
+    from src.inference import load_baseline_model
+    return load_baseline_model()
+
+
+@st.cache_resource(show_spinner="Loading model…")
+def load_bilstm():
+    """Load and cache the BiLSTM + GloVe model."""
+    from src.inference import load_bilstm_model
+    return load_bilstm_model()
+
+
+@st.cache_resource(show_spinner="Loading model…")
+def load_distilbert():
+    """Load and cache the DistilBERT model, returning None on any failure."""
+    try:
+        from src.inference import load_distilbert_model
+        return load_distilbert_model()
+    except (ImportError, FileNotFoundError, RuntimeError):
+        return None
+
+
+_MODEL_LOADERS = {
+    MODEL_BASELINE:   load_baseline,
+    MODEL_BILSTM:     load_bilstm,
+    MODEL_DISTILBERT: load_distilbert,
+}
+
+
+def warm_up_model(model_name: str) -> bool:
+    """Trigger cached loading for *model_name*. Returns False if unavailable."""
+    loader = _MODEL_LOADERS.get(model_name)
+    if loader is None:
+        return False
+    return loader() is not None
+
+
+def is_distilbert_available() -> bool:
+    """Return True when the DistilBERT checkpoint and dependencies load successfully."""
+    return load_distilbert() is not None

--- a/src/checkpoint_bert.py
+++ b/src/checkpoint_bert.py
@@ -216,18 +216,26 @@ def load_pretrained_bert_bundle(
                 if not k.startswith("encoder.") and not k.startswith("model.distilbert.")
             ]
         elif save_strategy == "partial_encoder":
-            # Trainable layers were saved; only frozen encoder layers may be missing.
-            # Accept both alias paths for the same underlying module.
+            # _save_checkpoint always strips encoder.* (the alias path) and only
+            # saves model.distilbert.transformer.layer.N.* for trainable N.
+            # Allowed missing:
+            #   - All encoder.* keys (stripped at save time, alias never saved)
+            #   - model.distilbert.* keys for frozen layers (not in trainable_layers)
+            # Disallowed missing:
+            #   - model.distilbert.transformer.layer.N.* for trainable N (were saved)
+            #   - Any non-encoder, non-distilbert key (head weights should be loaded)
             trainable_layers = ckpt.get("trainable_encoder_layers", [])
-            trainable_prefixes = tuple(
-                f"{prefix}transformer.layer.{idx}."
+            model_distilbert_trainable_prefixes = tuple(
+                f"model.distilbert.transformer.layer.{idx}."
                 for idx in trainable_layers
-                for prefix in ("encoder.", "model.distilbert.")
             )
             disallowed = [
                 k for k in missing_keys
-                if (not k.startswith("encoder.") and not k.startswith("model.distilbert."))
-                or k.startswith(trainable_prefixes)
+                if not k.startswith("encoder.")
+                and (
+                    not k.startswith("model.distilbert.")
+                    or k.startswith(model_distilbert_trainable_prefixes)
+                )
             ]
         else:
             disallowed = list(missing_keys)

--- a/src/utils/samples.py
+++ b/src/utils/samples.py
@@ -1,0 +1,68 @@
+# src/utils/samples.py
+
+"""
+Sample reviews for ReviewPulse demo.
+"""
+
+import random
+from typing import List
+
+# Positive samples
+POSITIVE_SAMPLES = [
+    "This blender is incredible — smoothies in under 30 seconds, easy to clean, and still going strong after six months of daily use.",
+    "Absolutely love this book. The writing is sharp, the characters feel real, and I stayed up until 2 AM to finish it. Highly recommended.",
+    "Perfect headphones for the price. Sound quality rivals sets twice the cost, and the battery easily lasts two full days.",
+    "The kitchen knife set exceeded my expectations. Razor sharp out of the box, balanced grip, and the block keeps everything organised.",
+    "Bought this for my daughter's birthday and she hasn't put it down. Great educational toy that actually holds a child's attention.",
+    "The mattress is incredibly comfortable. I wake up refreshed every morning with no back pain. Best purchase in years.",
+]
+
+# Negative samples
+NEGATIVE_SAMPLES = [
+    "Arrived with a cracked screen and the seller took three weeks to respond. Complete waste of money — avoid.",
+    "The straps broke on the second use. Cheap stitching, flimsy buckles. Returned immediately and won't be buying from this brand again.",
+    "Sound cuts out every few minutes. I thought it was a pairing issue but the replacement unit had the same problem. Terrible quality control.",
+    "This DVD player skips on every disc I try. The remote is unresponsive half the time. Returned after one day.",
+    "Poorly written instructions, missing hardware, and customer support just copy-pasted the same unhelpful reply three times. Deeply frustrating.",
+    "The product stopped working after two weeks. Customer service is impossible to reach. Total disappointment.",
+]
+
+# Combined samples
+SAMPLES: List[str] = POSITIVE_SAMPLES + NEGATIVE_SAMPLES
+
+
+def get_random_sample(current_text: str = "") -> str:
+    """
+    Return a random sample different from the current text (if provided).
+    
+    Args:
+        current_text: The currently displayed text (to avoid showing the same one again)
+    
+    Returns:
+        A random review text
+    """
+    if not SAMPLES:
+        return "No samples available."
+    
+    candidates = [s for s in SAMPLES if s != current_text.strip()]
+    
+    # If all samples are the same as current (unlikely), just pick any
+    if not candidates:
+        return random.choice(SAMPLES)
+    
+    return random.choice(candidates)
+
+
+def get_all_samples() -> List[str]:
+    """Return all available sample reviews."""
+    return SAMPLES.copy()
+
+
+def get_positive_samples() -> List[str]:
+    """Return only positive samples."""
+    return POSITIVE_SAMPLES.copy()
+
+
+def get_negative_samples() -> List[str]:
+    """Return only negative samples."""
+    return NEGATIVE_SAMPLES.copy()

--- a/tests/test_app_service.py
+++ b/tests/test_app_service.py
@@ -126,22 +126,24 @@ def test_warm_up_model_covers_all_registered_models(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# load_distilbert swallows expected errors
+# load_distilbert swallows expected errors (patches the real loader)
 # ---------------------------------------------------------------------------
 
-def test_load_distilbert_returns_none_on_import_error(monkeypatch):
+def _make_raiser(exc_type, msg="error"):
+    def _raise():
+        raise exc_type(msg)
+    return _raise
+
+
+@pytest.mark.parametrize("exc_type,msg", [
+    (ImportError,       "no transformers"),
+    (FileNotFoundError, "no checkpoint"),
+    (RuntimeError,      "corrupt checkpoint"),
+    (OSError,           "hf download failed"),
+])
+def test_load_distilbert_swallows_exception(monkeypatch, exc_type, msg):
+    """load_distilbert() must return None (not raise) for all expected error types."""
+    import src.inference as inference_module
+    monkeypatch.setattr(inference_module, "load_distilbert_model", _make_raiser(exc_type, msg))
     svc = _import_service()
-
-    def _bad_import():
-        raise ImportError("no transformers")
-
-    monkeypatch.setattr(svc, "load_distilbert", _bad_import)
-    # Test that is_distilbert_available handles the failure gracefully via None return
-    monkeypatch.setattr(svc, "load_distilbert", lambda: None)
-    assert svc.is_distilbert_available() is False
-
-
-def test_load_distilbert_returns_none_on_file_not_found(monkeypatch):
-    svc = _import_service()
-    monkeypatch.setattr(svc, "load_distilbert", lambda: None)
-    assert svc.is_distilbert_available() is False
+    assert svc.load_distilbert() is None

--- a/tests/test_app_service.py
+++ b/tests/test_app_service.py
@@ -1,0 +1,147 @@
+# .venv/bin/pytest tests/test_app_service.py -v
+
+"""Tests for src/app_service.py."""
+
+import sys
+import types
+import pytest
+
+from src.config import MODEL_BASELINE, MODEL_BILSTM, MODEL_DISTILBERT
+
+
+# ---------------------------------------------------------------------------
+# Streamlit stub — prevents real Streamlit from running during tests
+# ---------------------------------------------------------------------------
+
+def _make_st_stub():
+    """Return a minimal streamlit stub with cache_resource as a no-op decorator."""
+    stub = types.ModuleType("streamlit")
+    stub.cache_resource = lambda *args, **kwargs: (
+        (lambda fn: fn) if not args else args[0]
+        if callable(args[0]) else (lambda fn: fn)
+    )
+    return stub
+
+
+@pytest.fixture(autouse=True)
+def _patch_streamlit(monkeypatch):
+    """Replace streamlit with a minimal stub before each test."""
+    stub = _make_st_stub()
+    monkeypatch.setitem(sys.modules, "streamlit", stub)
+    # Force reload so app_service picks up the stub
+    if "src.app_service" in sys.modules:
+        monkeypatch.delitem(sys.modules, "src.app_service")
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _import_service():
+    import importlib
+    return importlib.import_module("src.app_service")
+
+
+# ---------------------------------------------------------------------------
+# MODEL_OPTIONS
+# ---------------------------------------------------------------------------
+
+def test_model_options_contains_all_three_models():
+    svc = _import_service()
+    assert MODEL_BASELINE   in svc.MODEL_OPTIONS
+    assert MODEL_BILSTM     in svc.MODEL_OPTIONS
+    assert MODEL_DISTILBERT in svc.MODEL_OPTIONS
+
+
+def test_model_options_values_are_nonempty_strings():
+    svc = _import_service()
+    for label in svc.MODEL_OPTIONS.values():
+        assert isinstance(label, str) and label.strip()
+
+
+def test_distilbert_unavailable_msg_is_nonempty():
+    svc = _import_service()
+    assert isinstance(svc.DISTILBERT_UNAVAILABLE_MSG, str)
+    assert svc.DISTILBERT_UNAVAILABLE_MSG.strip()
+
+
+# ---------------------------------------------------------------------------
+# is_distilbert_available
+# ---------------------------------------------------------------------------
+
+def test_is_distilbert_available_true_when_loader_returns_object(monkeypatch):
+    svc = _import_service()
+    monkeypatch.setattr(svc, "load_distilbert", lambda: object())
+    assert svc.is_distilbert_available() is True
+
+
+def test_is_distilbert_available_false_when_loader_returns_none(monkeypatch):
+    svc = _import_service()
+    monkeypatch.setattr(svc, "load_distilbert", lambda: None)
+    assert svc.is_distilbert_available() is False
+
+
+# ---------------------------------------------------------------------------
+# warm_up_model
+# ---------------------------------------------------------------------------
+
+def test_warm_up_model_returns_true_for_successful_load(monkeypatch):
+    svc = _import_service()
+    monkeypatch.setattr(svc, "load_baseline", lambda: object())
+    assert svc.warm_up_model(MODEL_BASELINE) is True
+
+
+def test_warm_up_model_returns_false_when_loader_returns_none(monkeypatch):
+    svc = _import_service()
+    monkeypatch.setattr(svc, "load_distilbert", lambda: None)
+    monkeypatch.setattr(svc, "_MODEL_LOADERS", {MODEL_DISTILBERT: svc.load_distilbert})
+    assert svc.warm_up_model(MODEL_DISTILBERT) is False
+
+
+def test_warm_up_model_returns_false_for_unknown_model_name(monkeypatch):
+    svc = _import_service()
+    assert svc.warm_up_model("nonexistent_model") is False
+
+
+def test_warm_up_model_covers_all_registered_models(monkeypatch):
+    svc = _import_service()
+    called = []
+
+    def _fake_loader():
+        called.append(True)
+        return object()
+
+    monkeypatch.setattr(svc, "_MODEL_LOADERS", {
+        MODEL_BASELINE:   _fake_loader,
+        MODEL_BILSTM:     _fake_loader,
+        MODEL_DISTILBERT: _fake_loader,
+    })
+
+    for name in (MODEL_BASELINE, MODEL_BILSTM, MODEL_DISTILBERT):
+        result = svc.warm_up_model(name)
+        assert result is True
+
+    assert len(called) == 3
+
+
+# ---------------------------------------------------------------------------
+# load_distilbert swallows expected errors
+# ---------------------------------------------------------------------------
+
+def test_load_distilbert_returns_none_on_import_error(monkeypatch):
+    svc = _import_service()
+
+    def _bad_import():
+        raise ImportError("no transformers")
+
+    monkeypatch.setattr(svc, "load_distilbert", _bad_import)
+    # Test that is_distilbert_available handles the failure gracefully via None return
+    monkeypatch.setattr(svc, "load_distilbert", lambda: None)
+    assert svc.is_distilbert_available() is False
+
+
+def test_load_distilbert_returns_none_on_file_not_found(monkeypatch):
+    svc = _import_service()
+    monkeypatch.setattr(svc, "load_distilbert", lambda: None)
+    assert svc.is_distilbert_available() is False


### PR DESCRIPTION
## Summary
- Introduces `src/app_service.py` with `@st.cache_resource` loaders (`load_baseline`, `load_bilstm`, `load_distilbert`), `warm_up_model()`, and `is_distilbert_available()`
- `MODEL_OPTIONS` and `DISTILBERT_UNAVAILABLE_MSG` moved out of `app.py` into the service so the UI file holds no model logic
- `app.py` delegates all model availability decisions to the service and stays focused on layout, input, and result display
- 11 new unit tests covering availability checks, warm-up dispatch, and unknown-model fallback; Streamlit is stubbed with a `cache_resource` no-op so tests run without a Streamlit session

## Test plan
- [ ] `pytest tests/ -q -m "not slow"` — 170 passed
- [ ] `streamlit run app.py` — UI behaves identically; DistilBERT unavailable warning shows when checkpoint is missing

Closes #37