### PR TITLE
test(arch): config contract tests and module boundary tests

### DIFF
--- a/tests/test_boundaries.py
+++ b/tests/test_boundaries.py
@@ -1,0 +1,95 @@
+# .venv/bin/pytest tests/test_boundaries.py -v
+
+"""Module boundary tests.
+
+Each test verifies that a module does not pull in code from a concern
+it must not own. Failures here indicate coupling that will make the
+refactor series unsafe.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+_PROJECT_ROOT = str(Path(__file__).parent.parent)
+
+
+def _assert_no_imports(module: str, forbidden: list[str], stub_streamlit: bool = False) -> None:
+    """Subprocess-import *module* and fail if any *forbidden* prefix appears in sys.modules."""
+    preamble = ""
+    if stub_streamlit:
+        preamble = (
+            "import sys, types; "
+            "stub = types.ModuleType('streamlit'); "
+            "stub.cache_resource = lambda *a, **kw: (a[0] if a and callable(a[0]) else lambda fn: fn); "
+            "sys.modules['streamlit'] = stub; "
+        )
+    check = (
+        f"bad = [m for m in sys.modules "
+        f"       if any(m == r or m.startswith(r + '.') for r in {forbidden!r})]; "
+        f"assert not bad, f'{{bad}}'"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", f"{preamble}import sys; import {module}; {check}"],
+        capture_output=True, text=True, cwd=_PROJECT_ROOT,
+    )
+    assert result.returncode == 0, (
+        f"{module!r} imported forbidden module(s):\n{result.stderr or result.stdout}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# src.config — dependency root; must import nothing from the rest of src
+# ---------------------------------------------------------------------------
+
+def test_config_does_not_import_any_src_module():
+    _assert_no_imports(
+        "src.config",
+        forbidden=["src.inference", "src.train", "src.train_bert",
+                   "src.evaluate", "src.baseline", "src.model",
+                   "src.dataset", "src.parser", "src.preprocess"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# src.inference — prediction layer; must not touch training or evaluation
+# ---------------------------------------------------------------------------
+
+def test_inference_does_not_import_train():
+    _assert_no_imports("src.inference", forbidden=["src.train", "src.train_bert"])
+
+
+def test_inference_does_not_import_evaluate():
+    _assert_no_imports("src.inference", forbidden=["src.evaluate"])
+
+
+def test_inference_does_not_import_parser():
+    _assert_no_imports("src.inference", forbidden=["src.parser"])
+
+
+# ---------------------------------------------------------------------------
+# src.app_service — presentation service; must not touch training
+# ---------------------------------------------------------------------------
+
+def test_app_service_does_not_import_train():
+    _assert_no_imports(
+        "src.app_service",
+        forbidden=["src.train", "src.train_bert"],
+        stub_streamlit=True,
+    )
+
+
+def test_app_service_does_not_import_evaluate():
+    _assert_no_imports(
+        "src.app_service",
+        forbidden=["src.evaluate"],
+        stub_streamlit=True,
+    )
+
+
+def test_app_service_does_not_import_parser():
+    _assert_no_imports(
+        "src.app_service",
+        forbidden=["src.parser"],
+        stub_streamlit=True,
+    )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,118 @@
+# .venv/bin/pytest tests/test_config.py -v
+
+"""Contract tests for src/config.py.
+
+These tests document what downstream modules depend on. If a constant
+changes name, type, or value the failure here pinpoints the breakage
+before it reaches inference, evaluate, or the app.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+from src.config import (
+    ALL_MODELS,
+    BASELINE_PATH,
+    BILSTM_CHECKPOINT_PATH,
+    DISTILBERT_PATH,
+    MODEL_BASELINE,
+    MODEL_BILSTM,
+    MODEL_DISTILBERT,
+    OUTPUTS_DIR,
+    PRED_THRESHOLD,
+    VOCAB_PATH,
+)
+
+_PROJECT_ROOT = str(Path(__file__).parent.parent)
+
+
+# ---------------------------------------------------------------------------
+# Path constants
+# ---------------------------------------------------------------------------
+
+def test_all_path_constants_are_path_instances():
+    for path in (OUTPUTS_DIR, BASELINE_PATH, BILSTM_CHECKPOINT_PATH, VOCAB_PATH, DISTILBERT_PATH):
+        assert isinstance(path, Path)
+
+
+def test_outputs_dir_name():
+    assert OUTPUTS_DIR.name == "outputs"
+
+
+def test_all_artifact_paths_are_under_outputs_dir():
+    for path in (BASELINE_PATH, BILSTM_CHECKPOINT_PATH, VOCAB_PATH, DISTILBERT_PATH):
+        assert path.parent == OUTPUTS_DIR
+
+
+def test_baseline_path_extension():
+    assert BASELINE_PATH.suffix == ".joblib"
+
+
+def test_bilstm_path_extension():
+    assert BILSTM_CHECKPOINT_PATH.suffix == ".pt"
+
+
+def test_vocab_path_extension():
+    assert VOCAB_PATH.suffix == ".json"
+
+
+def test_distilbert_path_extension():
+    assert DISTILBERT_PATH.suffix == ".pt"
+
+
+# ---------------------------------------------------------------------------
+# Model name constants
+# ---------------------------------------------------------------------------
+
+def test_model_name_constants_are_nonempty_strings():
+    for name in (MODEL_BASELINE, MODEL_BILSTM, MODEL_DISTILBERT):
+        assert isinstance(name, str) and name.strip()
+
+
+def test_model_names_are_distinct():
+    assert len({MODEL_BASELINE, MODEL_BILSTM, MODEL_DISTILBERT}) == 3
+
+
+def test_all_models_contains_each_constant():
+    assert MODEL_BASELINE   in ALL_MODELS
+    assert MODEL_BILSTM     in ALL_MODELS
+    assert MODEL_DISTILBERT in ALL_MODELS
+
+
+def test_all_models_length():
+    assert len(ALL_MODELS) == 3
+
+
+def test_all_models_no_duplicates():
+    assert len(set(ALL_MODELS)) == len(ALL_MODELS)
+
+
+# ---------------------------------------------------------------------------
+# Prediction threshold
+# ---------------------------------------------------------------------------
+
+def test_pred_threshold_is_float():
+    assert isinstance(PRED_THRESHOLD, float)
+
+
+def test_pred_threshold_in_open_unit_interval():
+    assert 0.0 < PRED_THRESHOLD < 1.0
+
+
+# ---------------------------------------------------------------------------
+# Module boundary — config must import nothing from src.*
+# ---------------------------------------------------------------------------
+
+def test_config_imports_no_other_src_modules():
+    result = subprocess.run(
+        [sys.executable, "-c",
+         "import sys; import src.config; "
+         "bad = [m for m in sys.modules "
+         "       if m.startswith('src.') and m not in ('src.config', 'src')]; "
+         "assert not bad, f'src.config pulled in: {bad}'"],
+        capture_output=True, text=True, cwd=_PROJECT_ROOT,
+    )
+    assert result.returncode == 0, (
+        f"src.config has unexpected imports:\n{result.stderr}"
+    )


### PR DESCRIPTION
## Summary
- **`tests/test_config.py`** (15 tests) — contract for every constant in `src/config.py`: Path types, file extensions, all artifacts under `OUTPUTS_DIR`, model name distinctness, `ALL_MODELS` completeness, `PRED_THRESHOLD` range. Includes a subprocess check that `src.config` imports nothing from the rest of `src`
- **`tests/test_boundaries.py`** (7 tests) — subprocess import-boundary tests: `src.config` has no `src.*` deps; `src.inference` doesn't pull in `src.train`/`src.train_bert`/`src.evaluate`/`src.parser`; `src.app_service` doesn't pull in training or data-loading code

No existing tests deleted. BERT tests remain guarded with `pytest.importorskip`.

## Test plan
- [ ] `pytest tests/ -q -m "not slow"` — 189 passed
- [ ] `pytest tests/` — 194 passed

Closes #39