### PR TITLE
refactor(data-module): move parser, preprocess, features into src/data/ (#57)

### DIFF
--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -1,0 +1,1 @@
+"""Data parsing and EDA helpers."""

--- a/src/data/features.py
+++ b/src/data/features.py
@@ -1,0 +1,138 @@
+"""EDA helper functions.
+
+All functions accept the raw DataFrame from load_all_domains() and return
+summary DataFrames or print reports. Plot functions optionally save to outputs/.
+"""
+
+import matplotlib.pyplot as plt
+import pandas as pd
+
+from src.config import OUTPUTS_DIR
+
+
+# --- summary tables ---
+
+def class_balance(df: pd.DataFrame) -> pd.DataFrame:
+    """Count and percentage of positive / negative reviews."""
+    counts = df["label"].value_counts().rename({1: "positive", 0: "negative"})
+    pct = (counts / len(df) * 100).round(1)
+    return pd.DataFrame({"count": counts, "pct": pct})
+
+
+def domain_balance(df: pd.DataFrame) -> pd.DataFrame:
+    """Review counts per domain, split by label."""
+    return (
+        df.groupby(["domain", "label"])
+        .size()
+        .unstack(fill_value=0)
+        .rename(columns={0: "negative", 1: "positive"})
+    )
+
+
+def rating_distribution(df: pd.DataFrame) -> pd.DataFrame:
+    """Rating value counts across the full dataset."""
+    return df["rating"].value_counts().sort_index().rename("count").to_frame()
+
+
+def length_stats(df: pd.DataFrame) -> pd.DataFrame:
+    """Descriptive statistics for review word counts."""
+    wc = df["text"].str.split().str.len()
+    stats = wc.describe(percentiles=[0.05, 0.25, 0.5, 0.75, 0.95]).round(1)
+    return stats.to_frame(name="word_count")
+
+
+def label_audit_summary(df: pd.DataFrame) -> pd.DataFrame:
+    """Run audit_labels and return a summary of flagged rows."""
+    from src.data.preprocess import audit_labels
+
+    audited = audit_labels(df)
+    summary = {
+        "total_reviews": len(df),
+        "ambiguous_3star": int(audited["is_ambiguous"].sum()),
+        "rating_conflicts": int(audited["rating_conflict"].sum()),
+        "clean_reviews": int((~audited["is_ambiguous"] & ~audited["rating_conflict"]).sum()),
+    }
+    return pd.DataFrame.from_dict(summary, orient="index", columns=["count"])
+
+
+# --- plots ---
+
+def plot_length_distribution(
+    df: pd.DataFrame,
+    min_words: int = 10,
+    max_words: int = 500,
+    save: bool = True,
+) -> None:
+    """Histogram of review word counts with outlier threshold lines."""
+    wc = df["text"].str.split().str.len()
+
+    fig, ax = plt.subplots(figsize=(10, 4))
+    ax.hist(wc, bins=80, color="#4C72B0", edgecolor="white", linewidth=0.4)
+    ax.axvline(min_words, color="#DD3333", linestyle="--", label=f"min={min_words}")
+    ax.axvline(max_words, color="#FF8800", linestyle="--", label=f"max={max_words}")
+    ax.set_xlabel("Word count")
+    ax.set_ylabel("Number of reviews")
+    ax.set_title("Review length distribution")
+    ax.legend()
+    fig.tight_layout()
+
+    if save:
+        OUTPUTS_DIR.mkdir(exist_ok=True)
+        path = OUTPUTS_DIR / "length_distribution.png"
+        fig.savefig(path, dpi=150)
+        print(f"Saved → {path}")
+
+    plt.show()
+
+
+def plot_domain_balance(df: pd.DataFrame, save: bool = True) -> None:
+    """Stacked bar chart of positive / negative counts per domain."""
+    balance = domain_balance(df)
+
+    fig, ax = plt.subplots(figsize=(8, 4))
+    balance.plot(
+        kind="bar",
+        ax=ax,
+        color=["#DD3333", "#4C72B0"],
+        edgecolor="white",
+        linewidth=0.4,
+        width=0.6,
+    )
+    ax.set_xlabel("Domain")
+    ax.set_ylabel("Number of reviews")
+    ax.set_title("Review counts per domain")
+    ax.set_xticklabels(balance.index, rotation=20, ha="right")
+    ax.legend(title="Label")
+    fig.tight_layout()
+
+    if save:
+        OUTPUTS_DIR.mkdir(exist_ok=True)
+        path = OUTPUTS_DIR / "domain_balance.png"
+        fig.savefig(path, dpi=150)
+        print(f"Saved → {path}")
+
+    plt.show()
+
+
+if __name__ == "__main__":
+    from src.data.parser import load_all_domains
+
+    df = load_all_domains()
+
+    print("=== Class balance ===")
+    print(class_balance(df), "\n")
+
+    print("=== Domain balance ===")
+    print(domain_balance(df), "\n")
+
+    print("=== Rating distribution ===")
+    print(rating_distribution(df), "\n")
+
+    print("=== Length stats ===")
+    print(length_stats(df), "\n")
+
+    print("=== Label audit summary ===")
+    print(label_audit_summary(df), "\n")
+
+    plot_length_distribution(df)
+    plot_domain_balance(df)

--- a/src/data/parser.py
+++ b/src/data/parser.py
@@ -1,0 +1,101 @@
+from pathlib import Path
+
+import pandas as pd
+from bs4 import BeautifulSoup
+
+DATA_DIR = Path(__file__).parent.parent.parent / "data"
+
+DOMAINS = {
+    "books": DATA_DIR / "books",
+    "dvd": DATA_DIR / "dvd",
+    "electronics": DATA_DIR / "electronics",
+    "kitchen": DATA_DIR / "kitchen_&_housewares",
+}
+
+# Primary label comes from the filename, not the star rating.
+# The rating is retained for auditing and ethics analysis in preprocess.py.
+LABEL_MAP = {
+    "positive.review": 1,
+    "negative.review": 0,
+}
+UNLABELED_FILENAME = "unlabeled.review"
+
+
+def parse_review_file(filepath: Path, label: int) -> list[dict]:
+    """Parse a single .review pseudo-XML file into a list of record dicts.
+
+    Skips any <review> block that has no <review_text> tag.
+    Missing <rating> is stored as None — handled downstream in audit_labels().
+    """
+    text = filepath.read_text(encoding="utf-8", errors="ignore")
+    soup = BeautifulSoup(text, "html.parser")
+    records = []
+    for review in soup.find_all("review"):
+        text_tag = review.find("review_text")
+        if text_tag is None:
+            continue
+        rating_tag = review.find("rating")
+        records.append({
+            "text": text_tag.get_text(strip=True),
+            "rating": float(rating_tag.get_text(strip=True)) if rating_tag else None,
+            "label": label,
+            "domain": None,       # filled by load_all_domains()
+            "source_file": filepath.name,
+        })
+    return records
+
+
+def _resolve_domain_path(data_dir: Path, domain_path: Path) -> Path:
+    """Resolve a domain path against a custom data directory when provided."""
+    return data_dir / domain_path.name if data_dir != DATA_DIR else domain_path
+
+
+def load_all_domains(data_dir: Path = DATA_DIR) -> pd.DataFrame:
+    """Load positive and negative reviews from all 4 domains.
+
+    Returns a DataFrame with columns: text, rating, label, domain, source_file.
+    """
+    records = []
+    for domain, domain_path in DOMAINS.items():
+        resolved = _resolve_domain_path(data_dir, domain_path)
+        for filename, label in LABEL_MAP.items():
+            filepath = resolved / filename
+            if not filepath.exists():
+                continue
+            domain_records = parse_review_file(filepath, label)
+            for r in domain_records:
+                r["domain"] = domain
+            records.extend(domain_records)
+
+    df = pd.DataFrame(records)
+    return df.reset_index(drop=True)
+
+
+def load_unlabeled_domains(data_dir: Path = DATA_DIR) -> pd.DataFrame:
+    """Load unlabeled reviews from all domains where the file exists.
+
+    Returns a DataFrame with the same schema as ``load_all_domains()``, but with
+    ``label`` fixed to ``-1`` to indicate that the text should only be used for
+    unsupervised workflows such as local pretraining.
+    """
+    records = []
+    for domain, domain_path in DOMAINS.items():
+        resolved = _resolve_domain_path(data_dir, domain_path)
+        filepath = resolved / UNLABELED_FILENAME
+        if not filepath.exists():
+            continue
+        domain_records = parse_review_file(filepath, label=-1)
+        for record in domain_records:
+            record["domain"] = domain
+        records.extend(domain_records)
+
+    df = pd.DataFrame(records)
+    return df.reset_index(drop=True)
+
+
+if __name__ == "__main__":
+    df = load_all_domains()
+    print(f"Loaded {len(df):,} reviews\n")
+    print(df.groupby(["domain", "label"]).size().unstack(fill_value=0).rename(columns={0: "negative", 1: "positive"}))
+    print(f"\nNull ratings: {df['rating'].isna().sum()}")
+    print(df.dtypes)

--- a/src/data/preprocess.py
+++ b/src/data/preprocess.py
@@ -1,0 +1,142 @@
+import re
+
+import pandas as pd
+from sklearn.model_selection import train_test_split
+
+SEED = 42
+MIN_WORDS = 10
+MAX_WORDS = 500
+
+# A "conflict" means the star rating contradicts the filename label.
+# e.g., a review in positive.review rated 1 or 2 stars is suspicious.
+_CONFLICT_POS_THRESHOLD = 3.0  # positive-file reviews rated below this are flagged
+_CONFLICT_NEG_THRESHOLD = 3.0  # negative-file reviews rated above this are flagged
+
+
+def audit_labels(df: pd.DataFrame) -> pd.DataFrame:
+    """Add audit columns to flag ambiguous or conflicting label/rating pairs.
+
+    Adds two boolean columns:
+        is_ambiguous    — True for 3-star reviews (no clear sentiment signal)
+        rating_conflict — True where the filename label contradicts the star rating
+    """
+    df = df.copy()
+    df["is_ambiguous"] = df["rating"] == 3.0
+    df["rating_conflict"] = (
+        ((df["label"] == 1) & (df["rating"] < _CONFLICT_POS_THRESHOLD)) |
+        ((df["label"] == 0) & (df["rating"] > _CONFLICT_NEG_THRESHOLD))
+    )
+    return df
+
+
+def drop_ambiguous(df: pd.DataFrame) -> pd.DataFrame:
+    """Drop 3-star and rating-conflicting reviews.
+
+    Ethical justification: 3-star reviews carry no clear positive or negative
+    signal — forcing them into either class introduces label noise. Rating
+    conflicts (e.g. a 1-star review in positive.review) suggest the filename
+    label does not reflect the reviewer's actual opinion. Dropping both
+    categories improves label quality and is documented as a data decision.
+    """
+    audited = audit_labels(df)
+    n_before = len(audited)
+    clean = audited[~audited["is_ambiguous"] & ~audited["rating_conflict"]].copy()
+    clean = clean.drop(columns=["is_ambiguous", "rating_conflict"])
+    print(f"drop_ambiguous: removed {n_before - len(clean)} rows  ({n_before} → {len(clean)})")
+    return clean.reset_index(drop=True)
+
+
+def clean_text(text: str) -> str:
+    """Normalise a review string for model input.
+
+    Steps:
+      1. Lowercase
+      2. Strip residual HTML tags
+      3. Expand negation contractions to preserve sentiment signal
+         (e.g. "don't" → "do not", so "not" survives punctuation removal)
+      4. Remove non-alphabetic characters
+      5. Collapse whitespace
+    """
+    text = text.lower()
+    text = re.sub(r"<[^>]+>", " ", text)
+    # Expand contractions before stripping punctuation
+    text = re.sub(r"n't", " not", text)
+    text = re.sub(r"'re", " are", text)
+    text = re.sub(r"'ve", " have", text)
+    text = re.sub(r"'ll", " will", text)
+    text = re.sub(r"'d", " would", text)
+    text = re.sub(r"'m", " am", text)
+    text = re.sub(r"[^a-z\s]", " ", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text
+
+
+def remove_outliers(
+    df: pd.DataFrame,
+    min_words: int = MIN_WORDS,
+    max_words: int = MAX_WORDS,
+) -> pd.DataFrame:
+    """Drop reviews outside the word-count range.
+
+    Default thresholds are heuristics — validate with EDA (features.py)
+    before treating them as ground truth.
+    """
+    counts = df["text"].str.split().str.len()
+    mask = (counts >= min_words) & (counts <= max_words)
+    print(f"remove_outliers: removed {(~mask).sum()} rows  (< {min_words} or > {max_words} words)")
+    return df[mask].reset_index(drop=True)
+
+
+def split_data(
+    df: pd.DataFrame,
+    val_size: float = 0.15,
+    test_size: float = 0.15,
+    seed: int = SEED,
+) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    """Stratified 70 / 15 / 15 train / validation / test split.
+
+    Stratification preserves the positive/negative ratio in each split.
+    The seed is fixed across all runs for reproducibility.
+    """
+    train_val, test = train_test_split(
+        df, test_size=test_size, random_state=seed, stratify=df["label"]
+    )
+    adjusted_val = val_size / (1.0 - test_size)
+    train, val = train_test_split(
+        train_val, test_size=adjusted_val, random_state=seed, stratify=train_val["label"]
+    )
+    print(f"split_data: train={len(train)}, val={len(val)}, test={len(test)}  (seed={seed})")
+    return (
+        train.reset_index(drop=True),
+        val.reset_index(drop=True),
+        test.reset_index(drop=True),
+    )
+
+
+def preprocess(df: pd.DataFrame) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    """Full preprocessing pipeline.
+
+    1. Drop ambiguous / conflicting labels
+    2. Clean text
+    3. Remove length outliers
+    4. Split into train / val / test
+    """
+    df = drop_ambiguous(df)
+    df = df.copy()
+    df["text"] = df["text"].map(clean_text)
+    df = remove_outliers(df)
+    return split_data(df)
+
+
+if __name__ == "__main__":
+    from src.data.parser import load_all_domains
+
+    raw = load_all_domains()
+    print(f"Raw: {len(raw)} reviews\n")
+
+    audited = audit_labels(raw)
+    print(f"Ambiguous (3-star):  {audited['is_ambiguous'].sum()}")
+    print(f"Rating conflicts:    {audited['rating_conflict'].sum()}\n")
+
+    train, val, test = preprocess(raw)
+    print(f"\nLabel balance — train:\n{train['label'].value_counts()}")

--- a/src/features.py
+++ b/src/features.py
@@ -1,138 +1,21 @@
-"""EDA helper functions.
+"""Compatibility wrapper for src.data.features."""
 
-All functions accept the raw DataFrame from load_all_domains() and return
-summary DataFrames or print reports. Plot functions optionally save to outputs/.
-"""
+from src.data.features import (
+    class_balance,
+    domain_balance,
+    label_audit_summary,
+    length_stats,
+    plot_domain_balance,
+    plot_length_distribution,
+    rating_distribution,
+)
 
-import matplotlib.pyplot as plt
-import pandas as pd
-
-from src.config import OUTPUTS_DIR
-
-
-# --- summary tables ---
-
-def class_balance(df: pd.DataFrame) -> pd.DataFrame:
-    """Count and percentage of positive / negative reviews."""
-    counts = df["label"].value_counts().rename({1: "positive", 0: "negative"})
-    pct = (counts / len(df) * 100).round(1)
-    return pd.DataFrame({"count": counts, "pct": pct})
-
-
-def domain_balance(df: pd.DataFrame) -> pd.DataFrame:
-    """Review counts per domain, split by label."""
-    return (
-        df.groupby(["domain", "label"])
-        .size()
-        .unstack(fill_value=0)
-        .rename(columns={0: "negative", 1: "positive"})
-    )
-
-
-def rating_distribution(df: pd.DataFrame) -> pd.DataFrame:
-    """Rating value counts across the full dataset."""
-    return df["rating"].value_counts().sort_index().rename("count").to_frame()
-
-
-def length_stats(df: pd.DataFrame) -> pd.DataFrame:
-    """Descriptive statistics for review word counts."""
-    wc = df["text"].str.split().str.len()
-    stats = wc.describe(percentiles=[0.05, 0.25, 0.5, 0.75, 0.95]).round(1)
-    return stats.to_frame(name="word_count")
-
-
-def label_audit_summary(df: pd.DataFrame) -> pd.DataFrame:
-    """Run audit_labels and return a summary of flagged rows."""
-    from src.preprocess import audit_labels
-
-    audited = audit_labels(df)
-    summary = {
-        "total_reviews": len(df),
-        "ambiguous_3star": int(audited["is_ambiguous"].sum()),
-        "rating_conflicts": int(audited["rating_conflict"].sum()),
-        "clean_reviews": int((~audited["is_ambiguous"] & ~audited["rating_conflict"]).sum()),
-    }
-    return pd.DataFrame.from_dict(summary, orient="index", columns=["count"])
-
-
-# --- plots ---
-
-def plot_length_distribution(
-    df: pd.DataFrame,
-    min_words: int = 10,
-    max_words: int = 500,
-    save: bool = True,
-) -> None:
-    """Histogram of review word counts with outlier threshold lines."""
-    wc = df["text"].str.split().str.len()
-
-    fig, ax = plt.subplots(figsize=(10, 4))
-    ax.hist(wc, bins=80, color="#4C72B0", edgecolor="white", linewidth=0.4)
-    ax.axvline(min_words, color="#DD3333", linestyle="--", label=f"min={min_words}")
-    ax.axvline(max_words, color="#FF8800", linestyle="--", label=f"max={max_words}")
-    ax.set_xlabel("Word count")
-    ax.set_ylabel("Number of reviews")
-    ax.set_title("Review length distribution")
-    ax.legend()
-    fig.tight_layout()
-
-    if save:
-        OUTPUTS_DIR.mkdir(exist_ok=True)
-        path = OUTPUTS_DIR / "length_distribution.png"
-        fig.savefig(path, dpi=150)
-        print(f"Saved → {path}")
-
-    plt.show()
-
-
-def plot_domain_balance(df: pd.DataFrame, save: bool = True) -> None:
-    """Stacked bar chart of positive / negative counts per domain."""
-    balance = domain_balance(df)
-
-    fig, ax = plt.subplots(figsize=(8, 4))
-    balance.plot(
-        kind="bar",
-        ax=ax,
-        color=["#DD3333", "#4C72B0"],
-        edgecolor="white",
-        linewidth=0.4,
-        width=0.6,
-    )
-    ax.set_xlabel("Domain")
-    ax.set_ylabel("Number of reviews")
-    ax.set_title("Review counts per domain")
-    ax.set_xticklabels(balance.index, rotation=20, ha="right")
-    ax.legend(title="Label")
-    fig.tight_layout()
-
-    if save:
-        OUTPUTS_DIR.mkdir(exist_ok=True)
-        path = OUTPUTS_DIR / "domain_balance.png"
-        fig.savefig(path, dpi=150)
-        print(f"Saved → {path}")
-
-    plt.show()
-
-
-if __name__ == "__main__":
-    from src.parser import load_all_domains
-
-    df = load_all_domains()
-
-    print("=== Class balance ===")
-    print(class_balance(df), "\n")
-
-    print("=== Domain balance ===")
-    print(domain_balance(df), "\n")
-
-    print("=== Rating distribution ===")
-    print(rating_distribution(df), "\n")
-
-    print("=== Length stats ===")
-    print(length_stats(df), "\n")
-
-    print("=== Label audit summary ===")
-    print(label_audit_summary(df), "\n")
-
-    plot_length_distribution(df)
-    plot_domain_balance(df)
+__all__ = [
+    "class_balance",
+    "domain_balance",
+    "rating_distribution",
+    "length_stats",
+    "label_audit_summary",
+    "plot_length_distribution",
+    "plot_domain_balance",
+]

--- a/src/parser.py
+++ b/src/parser.py
@@ -1,101 +1,21 @@
-from pathlib import Path
+"""Compatibility wrapper for src.data.parser."""
 
-import pandas as pd
-from bs4 import BeautifulSoup
+from src.data.parser import (
+    DATA_DIR,
+    DOMAINS,
+    LABEL_MAP,
+    UNLABELED_FILENAME,
+    load_all_domains,
+    load_unlabeled_domains,
+    parse_review_file,
+)
 
-DATA_DIR = Path(__file__).parent.parent / "data"
-
-DOMAINS = {
-    "books": DATA_DIR / "books",
-    "dvd": DATA_DIR / "dvd",
-    "electronics": DATA_DIR / "electronics",
-    "kitchen": DATA_DIR / "kitchen_&_housewares",
-}
-
-# Primary label comes from the filename, not the star rating.
-# The rating is retained for auditing and ethics analysis in preprocess.py.
-LABEL_MAP = {
-    "positive.review": 1,
-    "negative.review": 0,
-}
-UNLABELED_FILENAME = "unlabeled.review"
-
-
-def parse_review_file(filepath: Path, label: int) -> list[dict]:
-    """Parse a single .review pseudo-XML file into a list of record dicts.
-
-    Skips any <review> block that has no <review_text> tag.
-    Missing <rating> is stored as None — handled downstream in audit_labels().
-    """
-    text = filepath.read_text(encoding="utf-8", errors="ignore")
-    soup = BeautifulSoup(text, "html.parser")
-    records = []
-    for review in soup.find_all("review"):
-        text_tag = review.find("review_text")
-        if text_tag is None:
-            continue
-        rating_tag = review.find("rating")
-        records.append({
-            "text": text_tag.get_text(strip=True),
-            "rating": float(rating_tag.get_text(strip=True)) if rating_tag else None,
-            "label": label,
-            "domain": None,       # filled by load_all_domains()
-            "source_file": filepath.name,
-        })
-    return records
-
-
-def _resolve_domain_path(data_dir: Path, domain_path: Path) -> Path:
-    """Resolve a domain path against a custom data directory when provided."""
-    return data_dir / domain_path.name if data_dir != DATA_DIR else domain_path
-
-
-def load_all_domains(data_dir: Path = DATA_DIR) -> pd.DataFrame:
-    """Load positive and negative reviews from all 4 domains.
-
-    Returns a DataFrame with columns: text, rating, label, domain, source_file.
-    """
-    records = []
-    for domain, domain_path in DOMAINS.items():
-        resolved = _resolve_domain_path(data_dir, domain_path)
-        for filename, label in LABEL_MAP.items():
-            filepath = resolved / filename
-            if not filepath.exists():
-                continue
-            domain_records = parse_review_file(filepath, label)
-            for r in domain_records:
-                r["domain"] = domain
-            records.extend(domain_records)
-
-    df = pd.DataFrame(records)
-    return df.reset_index(drop=True)
-
-
-def load_unlabeled_domains(data_dir: Path = DATA_DIR) -> pd.DataFrame:
-    """Load unlabeled reviews from all domains where the file exists.
-
-    Returns a DataFrame with the same schema as ``load_all_domains()``, but with
-    ``label`` fixed to ``-1`` to indicate that the text should only be used for
-    unsupervised workflows such as local pretraining.
-    """
-    records = []
-    for domain, domain_path in DOMAINS.items():
-        resolved = _resolve_domain_path(data_dir, domain_path)
-        filepath = resolved / UNLABELED_FILENAME
-        if not filepath.exists():
-            continue
-        domain_records = parse_review_file(filepath, label=-1)
-        for record in domain_records:
-            record["domain"] = domain
-        records.extend(domain_records)
-
-    df = pd.DataFrame(records)
-    return df.reset_index(drop=True)
-
-
-if __name__ == "__main__":
-    df = load_all_domains()
-    print(f"Loaded {len(df):,} reviews\n")
-    print(df.groupby(["domain", "label"]).size().unstack(fill_value=0).rename(columns={0: "negative", 1: "positive"}))
-    print(f"\nNull ratings: {df['rating'].isna().sum()}")
-    print(df.dtypes)
+__all__ = [
+    "DATA_DIR",
+    "DOMAINS",
+    "LABEL_MAP",
+    "UNLABELED_FILENAME",
+    "load_all_domains",
+    "load_unlabeled_domains",
+    "parse_review_file",
+]

--- a/src/preprocess.py
+++ b/src/preprocess.py
@@ -1,142 +1,25 @@
-import re
+"""Compatibility wrapper for src.data.preprocess."""
 
-import pandas as pd
-from sklearn.model_selection import train_test_split
+from src.data.preprocess import (
+    MAX_WORDS,
+    MIN_WORDS,
+    SEED,
+    audit_labels,
+    clean_text,
+    drop_ambiguous,
+    preprocess,
+    remove_outliers,
+    split_data,
+)
 
-SEED = 42
-MIN_WORDS = 10
-MAX_WORDS = 500
-
-# A "conflict" means the star rating contradicts the filename label.
-# e.g., a review in positive.review rated 1 or 2 stars is suspicious.
-_CONFLICT_POS_THRESHOLD = 3.0  # positive-file reviews rated below this are flagged
-_CONFLICT_NEG_THRESHOLD = 3.0  # negative-file reviews rated above this are flagged
-
-
-def audit_labels(df: pd.DataFrame) -> pd.DataFrame:
-    """Add audit columns to flag ambiguous or conflicting label/rating pairs.
-
-    Adds two boolean columns:
-        is_ambiguous    — True for 3-star reviews (no clear sentiment signal)
-        rating_conflict — True where the filename label contradicts the star rating
-    """
-    df = df.copy()
-    df["is_ambiguous"] = df["rating"] == 3.0
-    df["rating_conflict"] = (
-        ((df["label"] == 1) & (df["rating"] < _CONFLICT_POS_THRESHOLD)) |
-        ((df["label"] == 0) & (df["rating"] > _CONFLICT_NEG_THRESHOLD))
-    )
-    return df
-
-
-def drop_ambiguous(df: pd.DataFrame) -> pd.DataFrame:
-    """Drop 3-star and rating-conflicting reviews.
-
-    Ethical justification: 3-star reviews carry no clear positive or negative
-    signal — forcing them into either class introduces label noise. Rating
-    conflicts (e.g. a 1-star review in positive.review) suggest the filename
-    label does not reflect the reviewer's actual opinion. Dropping both
-    categories improves label quality and is documented as a data decision.
-    """
-    audited = audit_labels(df)
-    n_before = len(audited)
-    clean = audited[~audited["is_ambiguous"] & ~audited["rating_conflict"]].copy()
-    clean = clean.drop(columns=["is_ambiguous", "rating_conflict"])
-    print(f"drop_ambiguous: removed {n_before - len(clean)} rows  ({n_before} → {len(clean)})")
-    return clean.reset_index(drop=True)
-
-
-def clean_text(text: str) -> str:
-    """Normalise a review string for model input.
-
-    Steps:
-      1. Lowercase
-      2. Strip residual HTML tags
-      3. Expand negation contractions to preserve sentiment signal
-         (e.g. "don't" → "do not", so "not" survives punctuation removal)
-      4. Remove non-alphabetic characters
-      5. Collapse whitespace
-    """
-    text = text.lower()
-    text = re.sub(r"<[^>]+>", " ", text)
-    # Expand contractions before stripping punctuation
-    text = re.sub(r"n't", " not", text)
-    text = re.sub(r"'re", " are", text)
-    text = re.sub(r"'ve", " have", text)
-    text = re.sub(r"'ll", " will", text)
-    text = re.sub(r"'d", " would", text)
-    text = re.sub(r"'m", " am", text)
-    text = re.sub(r"[^a-z\s]", " ", text)
-    text = re.sub(r"\s+", " ", text).strip()
-    return text
-
-
-def remove_outliers(
-    df: pd.DataFrame,
-    min_words: int = MIN_WORDS,
-    max_words: int = MAX_WORDS,
-) -> pd.DataFrame:
-    """Drop reviews outside the word-count range.
-
-    Default thresholds are heuristics — validate with EDA (features.py)
-    before treating them as ground truth.
-    """
-    counts = df["text"].str.split().str.len()
-    mask = (counts >= min_words) & (counts <= max_words)
-    print(f"remove_outliers: removed {(~mask).sum()} rows  (< {min_words} or > {max_words} words)")
-    return df[mask].reset_index(drop=True)
-
-
-def split_data(
-    df: pd.DataFrame,
-    val_size: float = 0.15,
-    test_size: float = 0.15,
-    seed: int = SEED,
-) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
-    """Stratified 70 / 15 / 15 train / validation / test split.
-
-    Stratification preserves the positive/negative ratio in each split.
-    The seed is fixed across all runs for reproducibility.
-    """
-    train_val, test = train_test_split(
-        df, test_size=test_size, random_state=seed, stratify=df["label"]
-    )
-    adjusted_val = val_size / (1.0 - test_size)
-    train, val = train_test_split(
-        train_val, test_size=adjusted_val, random_state=seed, stratify=train_val["label"]
-    )
-    print(f"split_data: train={len(train)}, val={len(val)}, test={len(test)}  (seed={seed})")
-    return (
-        train.reset_index(drop=True),
-        val.reset_index(drop=True),
-        test.reset_index(drop=True),
-    )
-
-
-def preprocess(df: pd.DataFrame) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
-    """Full preprocessing pipeline.
-
-    1. Drop ambiguous / conflicting labels
-    2. Clean text
-    3. Remove length outliers
-    4. Split into train / val / test
-    """
-    df = drop_ambiguous(df)
-    df = df.copy()
-    df["text"] = df["text"].map(clean_text)
-    df = remove_outliers(df)
-    return split_data(df)
-
-
-if __name__ == "__main__":
-    from src.parser import load_all_domains
-
-    raw = load_all_domains()
-    print(f"Raw: {len(raw)} reviews\n")
-
-    audited = audit_labels(raw)
-    print(f"Ambiguous (3-star):  {audited['is_ambiguous'].sum()}")
-    print(f"Rating conflicts:    {audited['rating_conflict'].sum()}\n")
-
-    train, val, test = preprocess(raw)
-    print(f"\nLabel balance — train:\n{train['label'].value_counts()}")
+__all__ = [
+    "SEED",
+    "MIN_WORDS",
+    "MAX_WORDS",
+    "audit_labels",
+    "drop_ambiguous",
+    "clean_text",
+    "remove_outliers",
+    "split_data",
+    "preprocess",
+]


### PR DESCRIPTION
## Issue #57 — Move Data Parsing and EDA Helpers

Moves raw-data and EDA concerns into a new `src/data/` package for cleaner separation of concerns.

### Changes
- **New files:** `src/data/{__init__,parser,preprocess,features}.py`
- **Modified:** `src/{parser,preprocess,features}.py` (now re-export wrappers)

### Backward Compatibility
✓ All old import paths still work (`from src.parser import ...`)
✓ Full test suite passes (193 tests, parser + preprocess tests verified)
✓ Zero behavior changes

### Verification
- Parser & preprocess tests: ✓ 32 passed
- Full fast suite: ✓ 193 passed, 5 deselected
- Boundary tests: ✓ passing

### Files Changed
```
A  src/data/__init__.py
A  src/data/features.py
A  src/data/parser.py
A  src/data/preprocess.py
M  src/features.py
M  src/parser.py
M  src/preprocess.py
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added data parsing and preprocessing pipeline for review datasets including text cleaning, outlier filtering, and train/validation/test splitting.
  * Added exploratory data analysis tools with summary statistics and visualization charts.
  * Added tokenization utilities supporting both BERT and sequence-based models with vocabulary building and GloVe embedding support.

* **Refactor**
  * Reorganized internal module structure for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->