### PR TITLE
refactor(tests): migrate to new src.data.* paths (#58)

### DIFF
--- a/tests/test_backward_compat.py
+++ b/tests/test_backward_compat.py
@@ -1,0 +1,58 @@
+# .venv/bin/pytest tests/test_backward_compat.py -v
+
+"""Backward compatibility tests.
+
+Verify that old import paths (src.parser, src.preprocess, src.features)
+still work via re-export wrappers, even after internal modules moved to src.data.
+
+These tests are not meant to be comprehensive; they verify that the wrapper
+re-exports are alive and functioning. Implementation tests are in the new paths.
+"""
+
+import pytest
+
+
+def test_can_import_from_old_parser_path():
+    """Verify src.parser re-export wrapper is importable."""
+    from src.parser import load_all_domains, parse_review_file
+    assert callable(load_all_domains)
+    assert callable(parse_review_file)
+
+
+def test_can_import_from_old_preprocess_path():
+    """Verify src.preprocess re-export wrapper is importable."""
+    from src.preprocess import audit_labels, clean_text, split_data
+    assert callable(audit_labels)
+    assert callable(clean_text)
+    assert callable(split_data)
+
+
+def test_can_import_from_old_features_path():
+    """Verify src.features re-export wrapper is importable."""
+    from src.features import class_balance, domain_balance
+    assert callable(class_balance)
+    assert callable(domain_balance)
+
+
+def test_old_parser_imports_delegate_to_new_path():
+    """Verify that old imports actually delegate to src.data.parser."""
+    from src.parser import load_all_domains as old_load
+    from src.data.parser import load_all_domains as new_load
+    # Both should be the same function object
+    assert old_load is new_load
+
+
+def test_old_preprocess_imports_delegate_to_new_path():
+    """Verify that old imports actually delegate to src.data.preprocess."""
+    from src.preprocess import clean_text as old_clean
+    from src.data.preprocess import clean_text as new_clean
+    # Both should be the same function object
+    assert old_clean is new_clean
+
+
+def test_old_features_imports_delegate_to_new_path():
+    """Verify that old imports actually delegate to src.data.features."""
+    from src.features import class_balance as old_balance
+    from src.data.features import class_balance as new_balance
+    # Both should be the same function object
+    assert old_balance is new_balance

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -156,8 +156,8 @@ def test_load_baseline_roundtrip(tmp_path):
 @pytest.mark.slow
 def test_baseline_real_data_accuracy():
     """Sanity check: baseline must exceed 80% accuracy on the real val split."""
-    from src.parser import load_all_domains
-    from src.preprocess import preprocess
+    from src.data.parser import load_all_domains
+    from src.data.preprocess import preprocess
     import tempfile
 
     raw = load_all_domains()

--- a/tests/test_boundaries.py
+++ b/tests/test_boundaries.py
@@ -47,7 +47,8 @@ def test_config_does_not_import_any_src_module():
         "src.config",
         forbidden=["src.inference", "src.train", "src.train_bert",
                    "src.evaluate", "src.baseline", "src.model",
-                   "src.dataset", "src.parser", "src.preprocess"],
+                   "src.dataset", "src.parser", "src.preprocess",
+                   "src.data.parser", "src.data.preprocess"],
     )
 
 
@@ -64,7 +65,7 @@ def test_inference_does_not_import_evaluate():
 
 
 def test_inference_does_not_import_parser():
-    _assert_no_imports("src.inference", forbidden=["src.parser"])
+    _assert_no_imports("src.inference", forbidden=["src.parser", "src.data.parser"])
 
 
 # ---------------------------------------------------------------------------
@@ -90,6 +91,6 @@ def test_app_service_does_not_import_evaluate():
 def test_app_service_does_not_import_parser():
     _assert_no_imports(
         "src.app.service",
-        forbidden=["src.parser"],
+        forbidden=["src.parser", "src.data.parser"],
         stub_streamlit=True,
     )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-from src.parser import load_all_domains, load_unlabeled_domains, parse_review_file
+from src.data.parser import load_all_domains, load_unlabeled_domains, parse_review_file
 
 # Minimal pseudo-XML fixture — mirrors the real .review file format
 SAMPLE_VALID = """

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -2,7 +2,7 @@
 
 import pandas as pd
 import pytest
-from src.preprocess import (
+from src.data.preprocess import (
     audit_labels,
     clean_text,
     drop_ambiguous,

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -177,8 +177,8 @@ def test_train_checkpoint_model_config_matches(tmp_path):
 def test_train_real_data_one_epoch():
     """One epoch on real data must complete without error and return val_f1 > 0."""
     import tempfile
-    from src.parser import load_all_domains
-    from src.preprocess import preprocess
+    from src.data.parser import load_all_domains
+    from src.data.preprocess import preprocess
     from src.dataset import save_vocab
 
     raw = load_all_domains()


### PR DESCRIPTION
## Issue #58 — Migrate Tests to New Package Paths

All tests now import from the canonical `src.data.*` locations.

### Changes
- **test_parser.py**: Updated to import from `src.data.parser`
- **test_preprocess.py**: Updated to import from `src.data.preprocess`
- **test_train.py**: Slow test updated to use new paths
- **test_baseline.py**: Slow test updated to use new paths
- **test_boundaries.py**: Updated to forbid both old and new paths where needed
- **NEW:** `test_backward_compat.py` — 6 tests verifying re-export wrappers work

### Verification
✓ All 203 tests pass  
✓ 38 parser/preprocess/backward-compat tests verified  
✓ Backward compatibility: old imports still work via wrappers  
✓ New paths: src.data.parser/preprocess/features are canonical  

### Files Changed
- M tests/test_parser.py
- M tests/test_preprocess.py  
- M tests/test_train.py
- M tests/test_baseline.py
- M tests/test_boundaries.py
- A tests/test_backward_compat.py